### PR TITLE
Make flask app context associate with new celery workers

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 db = SQLAlchemy()
 migrate = Migrate()
 mail = Mail()
-celery = Celery('aleph')
 assets = Environment()
 
 # these two queues are used so that background processing tasks
@@ -34,7 +33,7 @@ USER_QUEUE = 'user'
 USER_ROUTING_KEY = 'user.process'
 WORKER_QUEUE = 'worker'
 WORKER_ROUTING_KEY = 'worker.process'
-
+CELERYD_MAX_TASKS_PER_CHILD = int(os.environ.get('CELERYD_MAX_TASKS_PER_CHILD', '10'))
 
 def create_app(config={}):
     app = Flask('aleph')
@@ -63,14 +62,12 @@ def create_app(config={}):
 
     app.config['CELERY_DEFAULT_QUEUE'] = WORKER_QUEUE
     app.config['CELERY_DEFAULT_ROUTING_KEY'] = WORKER_ROUTING_KEY
+    app.config['CELERYD_MAX_TASKS_PER_CHILD'] = CELERYD_MAX_TASKS_PER_CHILD
+
     app.config['CELERY_QUEUES'] = (
         Queue(WORKER_QUEUE, routing_key=WORKER_ROUTING_KEY),
         Queue(USER_QUEUE, routing_key=USER_ROUTING_KEY),
     )
-    celery.conf.update(app.config)
-    celery.conf.update({
-        'BROKER_URL': app.config['CELERY_BROKER_URL']
-    })
 
     migrate.init_app(app, db, directory=app.config.get('ALEMBIC_DIR'))
     configure_oauth(app)
@@ -84,6 +81,24 @@ def create_app(config={}):
         plugin(app=app)
 
     return app
+
+
+def make_celery(flask_app):
+    celery = Celery('aleph', broker=flask_app.config['CELERY_BROKER_URL'])
+    celery.conf.update(flask_app.config)
+    celery.conf.update({
+        'BROKER_URL': flask_app.config['CELERY_BROKER_URL']
+    })
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        abstract = True
+
+        def __call__(self, *args, **kwargs):
+            with flask_app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+    celery.Task = ContextTask
+    return celery
 
 
 @migrate.configure
@@ -157,3 +172,5 @@ def url_for(*a, **kw):
         return flask_url_for(*a, **kw)
     except RuntimeError:
         return None
+
+celery = make_celery(create_app())

--- a/aleph/queue.py
+++ b/aleph/queue.py
@@ -1,4 +1,4 @@
-from aleph.core import create_app, celery as app  # noqa
+from aleph.core import create_app, make_celery  # noqa
 
 from aleph.ingest import ingest_url, ingest  # noqa
 from aleph.analyze import analyze_document_id  # noqa
@@ -9,4 +9,4 @@ from aleph.crawlers import execute_crawler  # noqa
 from aleph.events import save_event  # noqa
 
 flask_app = create_app()
-flask_app.app_context().push()
+app = make_celery(flask_app)


### PR DESCRIPTION
Was getting 'application not registered on db instance and no application bound to current context'
when celery workers were restarted because of CELERYD_MAX_TASKS_PER_CHILD
or when killed by the kernel to free memory. CELERYD_MAX_TASKS_PER_CHILD
is needed to keep memory use under control
http://chase-seibert.github.io/blog/2013/08/03/diagnosing-memory-leaks-python.html

This sets a conservative default of CELERYD_MAX_TASKS_PER_CHILD
and makes sure a new app context is given to a new worker.